### PR TITLE
include dockerfile and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.17.7 as builder
+LABEL maintainer="SkynetLabs <devs@skynetlabs.com>"
+
+WORKDIR /root
+
+COPY api api
+COPY clamav clamav
+COPY database database
+COPY scanner scanner
+COPY scanner scanner
+COPY go.mod go.sum main.go Makefile ./
+
+RUN go mod download && make release
+
+FROM golang:1.17.7-alpine
+LABEL maintainer="SkynetLabs <devs@skynetlabs.com>"
+
+COPY --from=builder /go/bin/malware-scanner /go/bin/malware-scanner
+
+ENTRYPOINT ["malware-scanner"]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@ MalwareScanner is a tool for scanning skylinks for malware.
 The service exposes a REST endpoint for reporting skylinks and takes care internally to queue them up and scan them.
 Once scanned, the skylinks are removed from the database and only their hashes are preserved, as to not keep any
 pointers to illegal content.
+
+## Running malware-scanner
+
+Pull latest image from https://hub.docker.com/repository/docker/skynetlabs/malware-scanner
+
+### Required env variables
+
+Skynet Portal Mongo Database Connection:
+
+- SKYNET_DB_HOST
+- SKYNET_DB_PORT
+- SKYNET_DB_USER
+- SKYNET_DB_PASS
+
+ClamAV:
+
+- CLAMAV_IP
+- CLAMAV_PORT


### PR DESCRIPTION
- include Dockerfile (to enable docker hub builds)
- include dependabot config to make sure the image dependencies are up to date
- update golang image from 1.17.3 to 1.17.7
- introduced multi stage build - build with debian and copy binary to alpine image to reduce image size
- updated maintainer email address
- removed redundant GOOS and GOARCH env vars - those are golang image defaults anyway
- removed defaults for malware-scanner environment variables - those defaults should be either in the code itself or should be set on usage, dockerfile should not be concerned with env variable configuration